### PR TITLE
Fix a typo and "its" diction

### DIFF
--- a/content/guides/journey-to-http2.md
+++ b/content/guides/journey-to-http2.md
@@ -65,7 +65,7 @@ One of the major drawbacks of `HTTP/1.0` were you couldn't have multiple request
 
 #### Three-way Handshake 
 
-Three-way handshake in it's simples form is that all the `TCP` connections begin with a three-way handshake in which the client and the server share a series of packets before starting to share the application data. 
+Three-way handshake in its simplest form is that all the `TCP` connections begin with a three-way handshake in which the client and the server share a series of packets before starting to share the application data. 
 
 - `SYN` - Client picks up a random number, let's say `x`, and sends it to the server.
 - `SYN ACK` - Server acknowledges the request by sending an `ACK` packet back to the client which is made up of a random number, let's say `y` picked up by server and the number `x+1` where `x` is the number that was sent by the client

--- a/content/guides/journey-to-http2.md
+++ b/content/guides/journey-to-http2.md
@@ -41,7 +41,7 @@ User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5)
 Accept: */*
 ```
 
-As you can see, alongside the request, client has also sent it's personal information, required response type etc. While in `HTTP/0.9` client could never send such information because there were no headers.
+As you can see, alongside the request, client has also sent its personal information, required response type etc. While in `HTTP/0.9` client could never send such information because there were no headers.
 
 Example response to the request above may have looked like below
 
@@ -79,11 +79,11 @@ Once the three-way handshake is completed, the data sharing between the client a
 
 However, some implementations of `HTTP/1.0` tried to overcome this issue by introducing a new header called `Connection: keep-alive` which was meant to tell the server "Hey server, do not close this connection, I need it again". But still, it wasn't that widely supported and the problem still persisted.
 
-Apart from being connectionless, `HTTP` also is a stateless protocol i.e. server doesn't maintain the information about the client and so each of the requests has to have the information necessary for the server to fulfill the request on it's own without any association with any old requests. And so this adds fuel to the fire i.e. apart from the large number of connections that the client has to open, it also has to send some redundant data on the wire causing increased bandwidth usage.
+Apart from being connectionless, `HTTP` also is a stateless protocol i.e. server doesn't maintain the information about the client and so each of the requests has to have the information necessary for the server to fulfill the request on its own without any association with any old requests. And so this adds fuel to the fire i.e. apart from the large number of connections that the client has to open, it also has to send some redundant data on the wire causing increased bandwidth usage.
 
 ### HTTP/1.1 - 1999
 
-After merely 3 years of `HTTP/1.0`, the next version i.e. `HTTP/1.1` was released in 1999; which made alot of improvements over it's predecessor. The major improvements over `HTTP/1.0` included
+After merely 3 years of `HTTP/1.0`, the next version i.e. `HTTP/1.1` was released in 1999; which made alot of improvements over its predecessor. The major improvements over `HTTP/1.0` included
 
 - **New HTTP methods** were added, which introduced `PUT`, `PATCH`, `OPTIONS`, `DELETE`
 
@@ -111,7 +111,7 @@ After merely 3 years of `HTTP/1.0`, the next version i.e. `HTTP/1.1` was release
 
 I am not going to dwell about all the `HTTP/1.1` features in this post as it is a topic in itself and you can already find a lot about it. The one such document that I would recommend you to read is [Key differences between `HTTP/1.0` and HTTP/1.1](http://www.ra.ethz.ch/cdstore/www8/data/2136/pdf/pd1.pdf) and here is the link to [original RFC](https://tools.ietf.org/html/rfc2616) for the overachievers.
 
-`HTTP/1.1` was introduced in 1999 and it had been a standard for many years. Although, it improved alot over it's predecessor; with the web changing everyday, it started to show it's age. Loading a web page these days is more resource-intensive than it ever was. A simple webpage these days has to open more than 30 connections. Well `HTTP/1.1` has persistent connections, then why so many connections? you say! The reason is, in `HTTP/1.1` it can only have one outstanding connection at any moment of time. `HTTP/1.1` tried to fix this by introducing pipelining but it didn't completely address the issue because of the **head-of-line blocking** where a slow or heavy request may block the requests behind and once a request gets stuck in a pipeline, it will have to wait for the next requests to be fulfilled. To overcome these shortcomings of `HTTP/1.1`, the developers started implementing the workarounds, for example use of spritesheets, encoded images in CSS, single humungous CSS/Javascript files, [domain sharding](https://www.maxcdn.com/one/visual-glossary/domain-sharding-2/) etc.
+`HTTP/1.1` was introduced in 1999 and it had been a standard for many years. Although, it improved alot over its predecessor; with the web changing everyday, it started to show its age. Loading a web page these days is more resource-intensive than it ever was. A simple webpage these days has to open more than 30 connections. Well `HTTP/1.1` has persistent connections, then why so many connections? you say! The reason is, in `HTTP/1.1` it can only have one outstanding connection at any moment of time. `HTTP/1.1` tried to fix this by introducing pipelining but it didn't completely address the issue because of the **head-of-line blocking** where a slow or heavy request may block the requests behind and once a request gets stuck in a pipeline, it will have to wait for the next requests to be fulfilled. To overcome these shortcomings of `HTTP/1.1`, the developers started implementing the workarounds, for example use of spritesheets, encoded images in CSS, single humungous CSS/Javascript files, [domain sharding](https://www.maxcdn.com/one/visual-glossary/domain-sharding-2/) etc.
 
 ### SPDY - 2009
 

--- a/content/project/backend-map.json
+++ b/content/project/backend-map.json
@@ -2810,7 +2810,7 @@
                     "y": "931",
                     "properties": {
                         "size": "15",
-                        "text": "Make sure to learn it’s quirks. Core detail about it's"
+                        "text": "Make sure to learn its quirks. Core detail about its"
                     }
                 },
                 {

--- a/scripts/path-map.js
+++ b/scripts/path-map.js
@@ -53,7 +53,7 @@ const getGuideRoutes = () => {
 };
 
 /**
- * Generates routes for each of the roadmap and it's respective versions
+ * Generates routes for each of the roadmap and its respective versions
  * @returns {*}
  */
 const getRoadmapRoutes = () => {


### PR DESCRIPTION
#### What roadmap does this PR target?

- [ ] Code Change
- [ ] Frontend Roadmap
- [x] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [x] Guides

#### Please acknowledge the items listed below

- [ ] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [ ] This is not a duplicate issue. I have searched and there is no existing issue for this. ( Fixes #129 )
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

Fixes a typo ("simplest" rather than "simples") and diction (using "its" where appropriate rather than "it's").
