### PR TITLE
fix incorrect link for resource in FE dev roadmap

### DIFF
--- a/content/roadmaps/1-frontend/resources.md
+++ b/content/roadmaps/1-frontend/resources.md
@@ -44,7 +44,7 @@ With the help of HTML, you create structure for your pages. CSS allows you to st
 ## Basics of JavaScript
 JavaScript allows you to add interactivity to your pages. Common examples that you may have seen on the websites are sliders, click interactions, popups and so on. In this section, you will learn the basics of JavaScript.
 
-* <BadgeLink badgeText='Read' href='https://www.w3schools.com/css/'>W3Schools – JavaScript Tutorial</BadgeLink>
+* <BadgeLink badgeText='Read' href='https://www.w3schools.com/js/'>W3Schools – JavaScript Tutorial</BadgeLink>
 * <BadgeLink variant='primary' badgeText='Watch' href='https://youtu.be/hdI2bqOjy3c?t=2'>JavaScript Crash Course for Beginners</BadgeLink>
 * <BadgeLink variant='primary' badgeText='Watch' href='https://youtu.be/P7t13SGytRk?t=22'>Build a Netflix Landing Page Clone with HTML, CSS & JS</BadgeLink>
 


### PR DESCRIPTION
#### What roadmap does this PR target?

- [ ] Code Change
- [x] Frontend Roadmap
- [ ] Backend Roadmap
- [ ] DevOps Roadmap
- [ ] All Roadmaps
- [ ] Guides

#### Please acknowledge the items listed below

- [ ] I have discussed this contribution and got a go-ahead in an issue before opening this pull request.
- [x] This is not a duplicate issue. I have searched and there is no existing issue for this.
- [x] I understand that these roadmaps are highly opinionated. The purpose is to not to include everything out there in these roadmaps but to have everything that is most relevant today comparing to the other options listed.
- [x] I have read the [contribution docs](../contributing) before opening this PR.

#### Enter the details about the contribution

<!-- Enter the details here -->
The link to the w3schools javascript tutorial for the 'basics of javascript' section currently links to the css tutorial - This fixes that